### PR TITLE
Simplify ns declaration

### DIFF
--- a/dev.cljs.edn
+++ b/dev.cljs.edn
@@ -1,5 +1,6 @@
 {:main cljs-spa.core
  :npm-deps false ;; this is important!
+ :language-out :ecmascript5
  :output-to "target/public/compiled/app.js"
  :foreign-libs [{:file "./doublebundle/dist/doublebundle.js",
                  :provides ["react" "react-dom" "create-react-class" "react-dom/server"

--- a/dev.cljs.edn
+++ b/dev.cljs.edn
@@ -1,6 +1,6 @@
 {:main cljs-spa.core
  :npm-deps false ;; this is important!
- :language-out :ecmascript5
+ :language-out :ecmascript5 ;; see https://dev.clojure.org/jira/browse/CLJS-2376
  :output-to "target/public/compiled/app.js"
  :foreign-libs [{:file "./doublebundle/dist/doublebundle.js",
                  :provides ["react" "react-dom" "create-react-class" "react-dom/server"

--- a/src/cljs_spa/page/home.cljs
+++ b/src/cljs_spa/page/home.cljs
@@ -1,6 +1,8 @@
 (ns cljs-spa.page.home
-  (:require [react-select :refer [default] :rename {default react-select}]
-            [cljs-spa.state :refer [!state]]))
+  (:require
+   ;; See https://github.com/pesterhazy/cljs-spa-example/issues/13
+   [react-select :refer [default] :rename {default react-select}]
+   [cljs-spa.state :refer [!state]]))
 
 (def options
   [{:value "simplicity" :label "simplicity"}

--- a/src/cljs_spa/page/home.cljs
+++ b/src/cljs_spa/page/home.cljs
@@ -1,5 +1,5 @@
 (ns cljs-spa.page.home
-  (:require [react-select :refer (default)]
+  (:require [react-select :refer (default) :rename {default foo}]
             [cljs-spa.state :refer [!state]]))
 
 (def options
@@ -8,7 +8,7 @@
    {:value "lazy sequences" :label "lazy sequences"}])
 
 (defn selector-ui []
-  (js/console.log "xxx" default react-select)
+  (js/console.log "xxx" foo react-select)
   [:div]
   #_[:> default
      {:is-multi true

--- a/src/cljs_spa/page/home.cljs
+++ b/src/cljs_spa/page/home.cljs
@@ -1,5 +1,5 @@
 (ns cljs-spa.page.home
-  (:require [react-select :as react-select]
+  (:require [react-select :refer (default)]
             [cljs-spa.state :refer [!state]]))
 
 (def options
@@ -8,13 +8,15 @@
    {:value "lazy sequences" :label "lazy sequences"}])
 
 (defn selector-ui []
-  [:> (.-default react-select)
-   {:is-multi true
-    :options (clj->js options)
-    :on-change (fn [xs] (swap! !state assoc :selection
-                               (->> (js->clj xs :keywordize-keys true)
-                                    (map :label)
-                                    (into #{}))))}])
+  (js/console.log "xxx" default react-select)
+  [:div]
+  #_[:> default
+     {:is-multi true
+      :options (clj->js options)
+      :on-change (fn [xs] (swap! !state assoc :selection
+                                 (->> (js->clj xs :keywordize-keys true)
+                                      (map :label)
+                                      (into #{}))))}])
 
 (defn result-ui []
   [:div

--- a/src/cljs_spa/page/home.cljs
+++ b/src/cljs_spa/page/home.cljs
@@ -1,5 +1,5 @@
 (ns cljs-spa.page.home
-  (:require [react-select :refer (default) :rename {default foo}]
+  (:require [react-select :refer [default] :rename {default react-select}]
             [cljs-spa.state :refer [!state]]))
 
 (def options
@@ -8,15 +8,13 @@
    {:value "lazy sequences" :label "lazy sequences"}])
 
 (defn selector-ui []
-  (js/console.log "xxx" foo react-select)
-  [:div]
-  #_[:> default
-     {:is-multi true
-      :options (clj->js options)
-      :on-change (fn [xs] (swap! !state assoc :selection
-                                 (->> (js->clj xs :keywordize-keys true)
-                                      (map :label)
-                                      (into #{}))))}])
+  [:> react-select
+   {:is-multi true
+    :options (clj->js options)
+    :on-change (fn [xs] (swap! !state assoc :selection
+                               (->> (js->clj xs :keywordize-keys true)
+                                    (map :label)
+                                    (into #{}))))}])
 
 (defn result-ui []
   [:div


### PR DESCRIPTION
Use the `:refer` and `:rename` options in the ns declaration to simplify using ES6 default exports

See https://dev.clojure.org/jira/browse/CLJS-2376