### PR TITLE
Add "s" to test in order to make it work

### DIFF
--- a/tests/cljs_spa/core_test.cljs
+++ b/tests/cljs_spa/core_test.cljs
@@ -31,7 +31,7 @@
   (testing "hello"
     (is (= 3 (+ 1 7)))))
 
-(deftest async-test-exepcted-to-fail-with-timeout
+(deftest async-test-expected-to-fail-with-timeout
   (promise-test (-> (slowly+ 500)
                     with-timeout+
                     (.then (fn [] (is (= 1 2)))))))

--- a/tests/cljs_spa/test_runner.cljs
+++ b/tests/cljs_spa/test_runner.cljs
@@ -7,7 +7,7 @@
 
 (defn extra-main []
   (js/console.warn "extra-main")
-  (run-tests (td/init! "app-test") 'cljs-spa.core-test))
+  (run-tests (td/init! "app-tests") 'cljs-spa.core-test))
 
 (defn -main [& args]
   (js/console.warn "-main")
@@ -16,6 +16,6 @@
 ;; Only run this at NS init time when the user
 ;; is visiting the extra main page
 
-(when (= "/figwheel-extra-main/test"
+(when (= "/figwheel-extra-main/tests"
          (gobj/getValueByKeys goog/global "location" "pathname"))
   (extra-main))


### PR DESCRIPTION
Awesome project again ! I really like the way it's easy to go on prod !

One thing about testing, I don't understand why but I get a page like this:

```
Figwheel Server: Resource not found
Keep on figwheelin' yep
```

When I'm trying to access http://localhost:9333/figwheel-extra-main/test

It started working as soon as I added some "s" in test_runner.cljs , as shown in the PR, and working when accessing http://localhost:9333/figwheel-extra-main/tests. I'm not sure what goes on there, does it work for you?

I also corrected a typo in the PR, nothing big.

Also, do you plan to make a branch of this with Re-frame ? I really like the way it works.

Thanks for the sharing ;)